### PR TITLE
add DNSResolver.gethostbyname()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,21 @@ For Trollius you should use another syntax like::
 API
 ===
 
-The API is pretty simple, two functions are provided in the ``DNSResolver`` class:
+The API is pretty simple, three functions are provided in the ``DNSResolver`` class:
 
 * ``query(host, type)``: Do a DNS resolution of the given type for the given hostname. It returns an
   instance of ``asyncio.Future``. The actual result of the DNS query is taken directly from pycares.
   As of version 1.0.0 of aiodns (and pycares, for that matter) results are always namedtuple-like
   objects with different attributes. Please check `the documentation <http://pycares.readthedocs.org/en/latest/channel.html#pycares.Channel.query>`_
   for the result fields.
+* ``gethostbyname(host, socket_family)``: Do a DNS resolution for the given
+  hostname and the desired type of address family (i.e. ``socket.AF_INET``).
+  While ``query()`` always performs a request to a DNS server,
+  ``gethostbyname()`` first looks into ``/etc/hosts`` and thus can resolve
+  local hostnames (such as ``localhost``).  Please check `the documentation
+  <http://pycares.readthedocs.io/en/latest/channel.html#pycares.Channel.gethostbyname>`_
+  for the result fields.
+  ``asyncio.Future``. The actual result of the call is a
 * ``cancel()``: Cancel all pending DNS queries. All futures will get ``DNSError`` exception set, with
   ``ARES_ECANCELLED`` errno.
 

--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,7 @@ class DNSTest(unittest.TestCase):
 
     def setUp(self):
         self.loop = asyncio.new_event_loop()
+        self.addCleanup(self.loop.close)
         self.resolver = aiodns.DNSResolver(loop=self.loop)
 
     def tearDown(self):

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     import trollius as asyncio
 import unittest
+import socket
 import sys
 
 import aiodns
@@ -130,6 +131,21 @@ class DNSTest(unittest.TestCase):
             ''')
 
         self.loop.run_until_complete(locals()['coro'](self, 'gmail.com', 'MX'))
+
+    def test_gethostbyname(self):
+        f = self.resolver.gethostbyname("google.com", socket.AF_INET)
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+
+    def test_gethostbyname_ipv6(self):
+        f = self.resolver.gethostbyname("ipv6.google.com", socket.AF_INET6)
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+
+    def test_gethostbyname_bad_family(self):
+        f = self.resolver.gethostbyname("ipv6.google.com", -1)
+        with self.assertRaises(aiodns.error.DNSError):
+            self.loop.run_until_complete(f)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a `gethostbyname()` method to `DNSResolver`.

`ares_query()` always performs a DNS query, while `ares_gethostbyname()` first checks `/etc/hosts`.
It matters when trying to resolve hostnames like `localhost` (as described in #17).

The `cb()` function defined in `query()` is now a static method of the class, as it is reused in `gethostbyname()`. I implemented three tests: one with `AF_INET`, `AF_INET6` and one with an incorrect integer value ensuring the error generated by ares is set in the future.

as a side, I ensured the loop is explicitly closed after each test to avoid `ResourceWarning`s being displayed.
