### PR TITLE
Fix Python version check

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -113,7 +113,7 @@ class DNSTest(unittest.TestCase):
 #            self.assertTrue(e)
 
     def test_query_twice(self):
-        if sys.version[:3] >= '3.3':
+        if sys.version_info >= (3, 3):
             exec('''if 1:
             @asyncio.coroutine
             def coro(self, host, qtype, n=2):


### PR DESCRIPTION
`sys.version[:3]` won't return the right thing in Python 3.10.
Use the [`sys.version_info`](https://docs.python.org/3/library/sys.html#sys.version_info) tuple instead.