### PR TITLE
implement gethostbyaddr for reverse lookups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ The API is pretty simple, three functions are provided in the ``DNSResolver`` cl
   local hostnames (such as ``localhost``).  Please check `the documentation
   <http://pycares.readthedocs.io/en/latest/channel.html#pycares.Channel.gethostbyname>`_
   for the result fields. The actual result of the call is a ``asyncio.Future``.
+* ``gethostbyaddr(name)``: Make a reverse lookup for an address.
 * ``cancel()``: Cancel all pending DNS queries. All futures will get ``DNSError`` exception set, with
   ``ARES_ECANCELLED`` errno.
 

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -89,6 +89,13 @@ class DNSResolver(object):
         self._channel.gethostbyname(host, family, cb)
         return fut
 
+    def gethostbyaddr(self, name):
+        # type: (str) -> asyncio.Future
+        fut = asyncio.Future(loop=self.loop)
+        cb = functools.partial(self._callback, fut)
+        self._channel.gethostbyaddr(name, cb)
+        return fut
+
     def cancel(self):
         # type: () -> None
         self._channel.cancel()

--- a/tests.py
+++ b/tests.py
@@ -138,6 +138,11 @@ class DNSTest(unittest.TestCase):
         result = self.loop.run_until_complete(f)
         self.assertTrue(result)
 
+    def test_gethostbyaddr(self):
+        f = self.resolver.gethostbyaddr("127.0.0.1")
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+
     def test_gethostbyname_ipv6(self):
         f = self.resolver.gethostbyname("ipv6.google.com", socket.AF_INET6)
         result = self.loop.run_until_complete(f)


### PR DESCRIPTION
Hi,

Thanks for this package! I have the need to make async reverse lookups.

I was able to add the `gethostbyaddr` from the pycares package here pretty quickly. Is this something that is interesting for you to support? If so please tell me if you need me to make changes to the testing or flesh out the documentation a bit more.

Please note that I don't know that much about the underlying mechanisms here.