### PR TITLE
Raise pycares dependency

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -140,7 +140,3 @@ class DNSResolver:
         else:
             self._timer = None
 
-    def __del__(self):
-        # type: () -> None
-        self._channel.destroy()
-

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name             = "aiodns",
       url              = "http://github.com/saghul/aiodns",
       description      = "Simple DNS resolver for asyncio",
       long_description = codecs.open("README.rst", encoding="utf-8").read(),
-      install_requires = ['pycares>=3.0.0b2', 'typing; python_version<"3.7"'],
+      install_requires = ['pycares>=3.0.0b4', 'typing; python_version<"3.7"'],
       packages         = ['aiodns'],
       platforms        = ["POSIX", "Microsoft Windows"],
       classifiers      = [


### PR DESCRIPTION
There is no Channel.destroy() method anymore.