### PR TITLE
Add tests indicating timeouts do not really work

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ import ipaddress
 import unittest
 import socket
 import sys
+import time
 
 import aiodns
 
@@ -88,10 +89,13 @@ class DNSTest(unittest.TestCase):
         self.resolver = aiodns.DNSResolver(timeout=0.1, loop=self.loop)
         self.resolver.nameservers = ['1.2.3.4']
         f = self.resolver.query('google.com', 'A')
+        started = time.monotonic()
         try:
             self.loop.run_until_complete(f)
         except aiodns.error.DNSError as e:
             self.assertEqual(e.args[0], aiodns.error.ARES_ETIMEOUT)
+        # Ensure timeout really cuts time deadline. Limit duration to one second
+        self.assertLess(time.monotonic() - started, 1)
 
     def test_query_cancel(self):
         f = self.resolver.query('google.com', 'A')


### PR DESCRIPTION
Hello!

This PR extends query timeout tests to ensure timeout has real influence on query duration. As you can see this test fails and outlines bug I actually met using aiodns. On my system query lasts 4 seconds instead of 0.1 secs and it seems to be timeout imposed by system (mine is Linux).

If needed, I can also open issue about this bug. My main question is: should I wait for fix or I should workaround this bug with something like `asyncio.wait_for`?