### PR TITLE
Updated README for proper display on PyPi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,8 @@ The API is pretty simple, three functions are provided in the ``DNSResolver`` cl
 * ``query(host, type)``: Do a DNS resolution of the given type for the given hostname. It returns an
   instance of ``asyncio.Future``. The actual result of the DNS query is taken directly from pycares.
   As of version 1.0.0 of aiodns (and pycares, for that matter) results are always namedtuple-like
-  objects with different attributes. Please check `the documentation <http://pycares.readthedocs.org/en/latest/channel.html#pycares.Channel.query>`_
+  objects with different attributes. Please check the `documentation 
+  <http://pycares.readthedocs.org/en/latest/channel.html#pycares.Channel.query>`_
   for the result fields.
 * ``gethostbyname(host, socket_family)``: Do a DNS resolution for the given
   hostname and the desired type of address family (i.e. ``socket.AF_INET``).


### PR DESCRIPTION
The current README does not display properly on PyPi. This is because the duplicate target name in the README `the documentation`. Current PR README can be viewed at https://test.pypi.org/project/aiodns/. Closes #67 