### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,21 @@ matrix:
       dist: xenial
       sudo: true
     - python: pypy3
+#power_jobs
+    - python: 3.5
+      arch: ppc64le
+    - python: 3.6
+      arch: ppc64le
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      arch: ppc64le
+# Disable version pypy3
+jobs: 
+  exclude:
+    - arch: ppc64le
+      python: pypy3
+      
 branches:
   only:
     - master


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.