### PR TITLE
Add PEP-561 with py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst LICENSE ChangeLog
 include setup.py tests.py
+include aiodns/py.typed
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 


### PR DESCRIPTION
Added the py.typed file so that when someone uses this library they can parse their typed with mypy

This was pointed out in #93 