### PR TITLE
Added a missing py.typed file for wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(name             = "aiodns",
       long_description_content_type = "text/x-rst",
       install_requires = ['pycares>=4.0.0'],
       packages         = ['aiodns'],
+      package_data     = {"aiodns": ["py.typed"]},
       platforms        = ["POSIX", "Microsoft Windows"],
       classifiers      = [
           "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Hi. Types and a py.typed marker have been added in PR #109.
The marker was also specified in [MANIFEST.in](https://github.com/saghul/aiodns/blob/master/MANIFEST.in#L3)

Unfortunately MANIFEST.in [does not affect](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#manifest-in) binary distributions such as wheels. 

This is the structure of the RECORD file during the installation of the package from wheel
```
aiodns-3.1.1.dist-info/INSTALLER,sha256=zuuue4knoyJ-UwPPXg8fezS7VCrXJQrAP7zeNuwvFQg,4
aiodns-3.1.1.dist-info/LICENSE,sha256=6wRV01EpQl7TmYg81xCSPePiRqUQ4uuE2fAAMtC77Jc,1070
aiodns-3.1.1.dist-info/METADATA,sha256=qM6KoP0Ot6pFAF-izMoNBgmGsIlTQfieU4X0nN5lobI,3994
aiodns-3.1.1.dist-info/RECORD,,
aiodns-3.1.1.dist-info/REQUESTED,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
aiodns-3.1.1.dist-info/WHEEL,sha256=yQN5g4mg4AybRjkgi-9yy4iQEFibGQmlz78Pik5Or-A,92
aiodns-3.1.1.dist-info/top_level.txt,sha256=5J2m3NWP4dezFZNpQoHaj8mv472iPcUzFboQoqWcEe4,7
aiodns/__init__.py,sha256=8uXR1WHCoHlToHl4AH_EaxAxpsA4oIiyor8DABjsvq4,5742
aiodns/__pycache__/__init__.cpython-312.pyc,,
aiodns/__pycache__/error.cpython-312.pyc,,
aiodns/error.py,sha256=fnNPLc8ceLk9drumwt-6Un5iiowyWApTe_VIoJ5gT5U,134
```
