### PR TITLE
Add Winloop as a valid EventLoop

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -52,8 +52,14 @@ class DNSResolver:
         assert self.loop is not None
         if sys.platform == 'win32':
             if not isinstance(self.loop, asyncio.SelectorEventLoop):
-                raise RuntimeError(
-                    'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
+                try:
+                    import winloop
+                    if not isinstance(self.loop , winloop.Loop):
+                        raise RuntimeError(
+                            'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
+                except ModuleNotFoundError:
+                    raise RuntimeError(
+                        'aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86')
         kwargs.pop('sock_state_cb', None)
         timeout = kwargs.pop('timeout', None)
         self._timeout = timeout

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,7 @@ try:
         skip_uvloop = False
     else:
         import uvloop 
-        skip_uvloop = True
+        skip_uvloop = False
 except ModuleNotFoundError:
     skip_uvloop = True
 

--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,16 @@ import time
 
 import aiodns
 
+try:
+    if sys.platform == "win32":
+        import winloop as uvloop
+        skip_uvloop = False
+    else:
+        import uvloop 
+        skip_uvloop = True
+except ModuleNotFoundError:
+    skip_uvloop = True
+
 
 class DNSTest(unittest.TestCase):
     def setUp(self):
@@ -162,6 +172,14 @@ class DNSTest(unittest.TestCase):
 #        result = self.loop.run_until_complete(f)
 #        self.assertTrue(result)
 
+@unittest.skipIf(skip_uvloop, "We don't have a uvloop or winloop module")
+class TestUV_DNS(DNSTest):
+    def setUp(self):
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        self.loop = asyncio.new_event_loop()
+        self.addCleanup(self.loop.close)
+        self.resolver = aiodns.DNSResolver(loop=self.loop, timeout=5.0)
+        self.resolver.nameservers = ['8.8.8.8']
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
So I recently tried to see if `winloop`  would be another valid option since it is not tied to the `ProctorEventLoop` in any way shape or form and I was able to spin up a quick unittest once I modified aiodns's dns resolver to work with my library.

```python
try:
    import aiodns
except ImportError:
    skip_tests = True
else:
    skip_tests = False

import asyncio
import sys
import unittest
import weakref

from winloop import _testbase as tb


class _TestAiodns:
    def test_dns_query(self):
        # This is not allowed to fail...
        resolver = aiodns.DNSResolver(loop=self.loop)

        async def test():
            async def query(name, query_type):
                return await resolver.query(name, query_type)
            await query('google.com', 'A')
            await query('httpbin.org', 'A')
            await query('example.com', 'A')

        self.loop.run_until_complete(test())


@unittest.skipIf(skip_tests, "no aiodns module")
class Test_UV_Aiodns(_TestAiodns, tb.UVTestCase):
    pass


@unittest.skip("aiodns needs a SelectorEventLoop on Windows. See more: https://github.com/saghul/aiodns/issues/86")
class Test_AIO_Aiodns(_TestAiodns, tb.AIOTestCase):
    pass
```
btw I am the main developer of winloop.