### PR TITLE
Add support for getaddrinfo

### DIFF
--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -111,7 +111,7 @@ class DNSResolver:
         self._channel.gethostbyname(host, family, cb)
         return fut
     
-    def getaddrinfo(self, host: str, family: socket.AddressFamily = 0, port: Optional[int] = None, proto: int = 0, type: int = 0, flags: int = 0) -> asyncio.Future:
+    def getaddrinfo(self, host: str, family: socket.AddressFamily = socket.AF_UNSPEC, port: Optional[int] = None, proto: int = 0, type: int = 0, flags: int = 0) -> asyncio.Future:
         fut = asyncio.Future(loop=self.loop)  # type: asyncio.Future
         cb = functools.partial(self._callback, fut)
         self._channel.getaddrinfo(host, port, cb, family=family, type=type, proto=proto, flags=flags)

--- a/aiodns/__init__.py
+++ b/aiodns/__init__.py
@@ -110,6 +110,12 @@ class DNSResolver:
         cb = functools.partial(self._callback, fut)
         self._channel.gethostbyname(host, family, cb)
         return fut
+    
+    def getaddrinfo(self, host: str, family: socket.AddressFamily = 0, port: Optional[int] = None, proto: int = 0, type: int = 0, flags: int = 0) -> asyncio.Future:
+        fut = asyncio.Future(loop=self.loop)  # type: asyncio.Future
+        cb = functools.partial(self._callback, fut)
+        self._channel.getaddrinfo(host, port, cb, family=family, type=type, proto=proto, flags=flags)
+        return fut
 
     def gethostbyaddr(self, name: str) -> asyncio.Future:
         fut = asyncio.Future(loop=self.loop)  # type: asyncio.Future

--- a/tests.py
+++ b/tests.py
@@ -151,6 +151,26 @@ class DNSTest(unittest.TestCase):
         result = self.loop.run_until_complete(f)
         self.assertTrue(result)
 
+    def test_getaddrinfo_address_family_0(self):
+        f = self.resolver.getaddrinfo('google.com')
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+        self.assertTrue(len(result.nodes) > 1)
+
+    def test_getaddrinfo_address_family_af_inet(self):
+        f = self.resolver.getaddrinfo('google.com', socket.AF_INET)
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+        self.assertTrue(len(result.nodes) == 1)
+        self.assertTrue(result.nodes[0].family == socket.AF_INET)
+
+    def test_getaddrinfo_address_family_af_inet6(self):
+        f = self.resolver.getaddrinfo('google.com', socket.AF_INET6)
+        result = self.loop.run_until_complete(f)
+        self.assertTrue(result)
+        self.assertTrue(len(result.nodes) == 1)
+        self.assertTrue(result.nodes[0].family == socket.AF_INET6)
+
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyaddr(self):
         f = self.resolver.gethostbyaddr('127.0.0.1')

--- a/tests.py
+++ b/tests.py
@@ -161,15 +161,13 @@ class DNSTest(unittest.TestCase):
         f = self.resolver.getaddrinfo('google.com', socket.AF_INET)
         result = self.loop.run_until_complete(f)
         self.assertTrue(result)
-        self.assertTrue(len(result.nodes) == 1)
-        self.assertTrue(result.nodes[0].family == socket.AF_INET)
+        self.assertTrue(all(node.family == socket.AF_INET for node in result.nodes))
 
     def test_getaddrinfo_address_family_af_inet6(self):
         f = self.resolver.getaddrinfo('google.com', socket.AF_INET6)
         result = self.loop.run_until_complete(f)
         self.assertTrue(result)
-        self.assertTrue(len(result.nodes) == 1)
-        self.assertTrue(result.nodes[0].family == socket.AF_INET6)
+        self.assertTrue(all(node.family == socket.AF_INET6 for node in result.nodes))
 
     @unittest.skipIf(sys.platform == 'win32', 'skipped on Windows')
     def test_gethostbyaddr(self):


### PR DESCRIPTION
The end goal is to be able to use this in aiohttp's resolver https://github.com/aio-libs/aiohttp/blob/aa014a9c1084368a01a79f09bb238486e0aa164a/aiohttp/resolver.py#L91 as the current implementation doesn't return both IPv6 and IPv4 addresses which provides different semantics than the threaded resolver which uses python's built-in `getaddrinfo`

fixes #23 https://github.com/saghul/aiodns/issues/23#issuecomment-1055456917

We are going to be rolling out Happy Eyeballs support in `aiohttp` 3.10.x so it would be nice to be able to avoid the threads